### PR TITLE
Correctly find default spec for patch skew

### DIFF
--- a/data/files/providers.go
+++ b/data/files/providers.go
@@ -154,37 +154,34 @@ func GetDefaultClusterSpec(provider string, x *version.Version) (*api.ClusterSpe
 	if !found {
 		return nil, fmt.Errorf("Can't find cluster provider %v", provider)
 	}
+	firstPatch := x.Clone().ToMutator().ResetPrerelease().ResetMetadata().ResetPatch().Done() // x.y.0
+	sanitizedX := x.Clone().ToMutator().ResetPrerelease().ResetMetadata().Done()              // x.y.z
+
+	xGE, err := version.NewConstraint(fmt.Sprintf(">= %s", firstPatch.String()))
+	if err != nil {
+		return nil, err
+	}
+	xWB, err := version.NewConstraint(fmt.Sprintf(">= %s, <= %s", firstPatch.String(), sanitizedX.String()))
+	if err != nil {
+		return nil, err
+	}
+
 	// ref: https://golang.org/pkg/sort/#Search
-	pos := sort.Search(len(p.Versions), func(i int) bool { return !p.Versions[i].Version.LessThan(x) })
-	if pos < len(p.Versions) && p.Versions[pos].Version.Equal(x) {
-		c, err := version.NewConstraint(fmt.Sprintf(">= %s, <= %s", x.Clone().ToMutator().ResetMetadata().ResetPatch().Done().String(), x.Clone().ToMutator().ResetMetadata().Done().String()))
+	pos := sort.Search(len(p.Versions), func(i int) bool { return xGE.Check(p.Versions[i].Version) })
+	if pos < len(p.Versions) && xWB.Check(p.Versions[pos].Version) {
+		// perform deep copy so that cache is not modified
+		var result api.ClusterSpec
+		b, err := json.Marshal(p.Versions[pos].DefaultSpec)
 		if err != nil {
 			return nil, err
 		}
-		i := pos
-		for i >= 0 {
-			if i != pos && !c.Check(p.Versions[i].Version) { // ensures that pre versions don't fail constraint
-				break
-			}
-			if p.Versions[i].DefaultSpec != nil {
-				// perform deep copy so that cache is not modified
-				var result api.ClusterSpec
-				b, err := json.Marshal(p.Versions[i].DefaultSpec)
-				if err != nil {
-					return nil, err
-				}
-				err = json.Unmarshal(b, &result)
-				if err != nil {
-					return nil, err
-				}
-				return &result, nil
-			}
-			i--
+		err = json.Unmarshal(b, &result)
+		if err != nil {
+			return nil, err
 		}
-		return nil, fmt.Errorf("Can't find default spec for Kubernetes version %v for provider %v", x, provider)
-	} else {
-		return nil, fmt.Errorf("Can't find Kubernetes version %v for provider %v", x, provider)
+		return &result, nil
 	}
+	return nil, fmt.Errorf("can't find default spec for Kubernetes version %v for provider %v", x, provider)
 }
 
 func GetInstanceType(provider, sku string) (*data.InstanceType, error) {

--- a/data/files/providers_test.go
+++ b/data/files/providers_test.go
@@ -1,10 +1,14 @@
 package files_test
 
 import (
+	"fmt"
+	"sort"
 	"testing"
 
 	_env "github.com/appscode/go/env"
 	. "github.com/appscode/pharmer/data/files"
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestName(t *testing.T) {
@@ -28,4 +32,20 @@ func TestLoadForDevEnv(t *testing.T) {
 	if err := Load(_env.Dev); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestVersion(t *testing.T) {
+	v170, _ := version.NewVersion("1.7.0")
+	v180, _ := version.NewVersion("1.8.0")
+	v190, _ := version.NewVersion("1.9.0")
+	v181, _ := version.NewVersion("1.8.1")
+
+	c2, err := version.NewConstraint(fmt.Sprintf(">= %s", v181.Clone().ToMutator().ResetPrerelease().ResetMetadata().ResetPatch().Done().String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	versions := []*version.Version{v170, v190, v180}
+	pos := sort.Search(len(versions), func(i int) bool { return c2.Check(versions[i]) })
+	assert.Equal(t, 1, pos)
 }


### PR DESCRIPTION
This allows creating cluster for 1.8.1 even though data files only has 1.8.0 .