### PR TITLE
Install kubeadm-probe as a critical addon

### DIFF
--- a/addons/kubeadm-probe/ds.yaml
+++ b/addons/kubeadm-probe/ds.yaml
@@ -40,11 +40,14 @@ metadata:
   namespace: kube-system
   labels:
     app: kubeadm-probe
+
 spec:
   template:
     metadata:
       labels:
         name: kubeadm-probe
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
@@ -53,6 +56,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
       serviceAccountName: kubeadm-probe
       containers:
       - image: busybox


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/

Example:
https://github.com/kubernetes/kubernetes/blob/4f2d7b93da2464a3147e0a7e71d896dd2bade9ad/cluster/addons/dashboard/dashboard-controller.yaml